### PR TITLE
Fix incorrect name mangling

### DIFF
--- a/smbclient/_io.py
+++ b/smbclient/_io.py
@@ -159,7 +159,7 @@ def _resolve_dfs(raw_io):
     if not info:
         raise ObjectPathNotFound()
 
-    connection_kwargs = getattr(raw_io, '_%s__kwargs' % type(raw_io).__name__, {})
+    connection_kwargs = getattr(raw_io, '_%s__kwargs' % SMBRawIO.__name__, {})
 
     for target in info:
         new_path = raw_path.replace(info.dfs_path, target.target_path, 1)


### PR DESCRIPTION
Since self.__kwargs is set in SMBRawIO.__init__, its name will always be _SMBRawIO__kwargs.
This fixes connection_cache not being passed to get_smb_tree in dfs referrals